### PR TITLE
[Chore] CD workflow 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,30 +42,5 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DEPLOY_WEBHOOK_URL }}
           DISCORD_USERNAME: 배포봇
-          DISCORD_EMBEDS: |
-            [
-              {
-                "author": {
-                  "name": "${{ github.event.pull_request.user.login }}",
-                  "url": "https://github.com/techbloghub/server",
-                  "icon_url": "${{ github.event.pull_request.user.avatar_url }}"
-                },
-                "title": "배포 실패! \n #${{ github.event.pull_request.number }} : ${{ github.event.pull_request.title }}",
-                "color": 13458524,
-                "description": "${{ github.event.pull_request.html_url }}",
-                "fields": [
-                  {
-                    "name": "Base Branch",
-                    "value": "${{ github.base_ref }}",
-                    "inline": true
-                  },
-                  {
-                    "name": "Compare Branch",
-                    "value": "${{ github.head_ref }}",
-                    "inline": true
-                  }
-                ]
-              }
-            ]
         with:
-          args: ''
+          args: 'The deployment of techbloghub/{{ EVENT_PAYLOAD.repository.full_name }} has failed'


### PR DESCRIPTION
- 라이브러리 버전 업데이트
- 배포 스크립트 실행 시 불필요한 권한 부여 및 sudo 키워드 제거
- 배포 실패 푸시 형식 변경


## 고민되는 것
배포 스크립트는 현재 public repository인 점을 고려, 배포된 서버에 쉘 스크립트로 만들어두었다.
코드레벨에서 관리할 수 있는 방법은 없을까?
