### PR TITLE
feat: 태그 검색 기능 추가

### DIFF
--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -66,8 +66,7 @@ func applySearchFilters(query *ent.PostingQuery, title, tags string) *ent.Postin
 	// tags: [react,java]
 	// query : where tags @> ARRAY['react','java']
 	if tags != "" {
-		trimmed := strings.Trim(tags, "[]")
-		arr := strings.Split(trimmed, ",")
+		arr := strings.Split(tags, ",")
 		arrayQuery := "ARRAY" + fmt.Sprintf("['%s']", strings.Join(arr, ","))
 
 		query = query.Where(func(s *sql.Selector) {

--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -31,6 +31,7 @@ type PostingSearchResponses struct {
 func GetPostings(client *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		titleSearchParam := c.DefaultQuery("title", "")
+		tagsSearchParam := c.DefaultQuery("tags", "")
 		paging := common.GenerateTechPaging(c.Query("cursor"), c.Query("size"))
 
 		totalCount, err := countTotalPostings(client, titleSearchParam, c)

--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/techbloghub/server/internal/common"
 )
 
-type TitleSearchResponse struct {
+type PostingSearchResponse struct {
 	ID            int       `json:"posting_id"`
 	Title         string    `json:"title"`
 	Url           string    `json:"url"`
@@ -26,9 +26,9 @@ type TitleSearchResponse struct {
 }
 
 type PostingSearchResponses struct {
-	Count       int                   `json:"count"`
-	Postings    []TitleSearchResponse `json:"postings"`
-	HasNextPage bool                  `json:"has_next_page"`
+	Count       int                     `json:"count"`
+	Postings    []PostingSearchResponse `json:"postings"`
+	HasNextPage bool                    `json:"has_next_page"`
 }
 
 func GetPostings(client *ent.Client) gin.HandlerFunc {
@@ -126,10 +126,10 @@ func countTotalPostings(client *ent.Client, param string, c *gin.Context) (int, 
 	return query.Count(c)
 }
 
-func convertToTitleSearchResponse(postings []*ent.Posting) []TitleSearchResponse {
-	responses := make([]TitleSearchResponse, len(postings))
+func convertToTitleSearchResponse(postings []*ent.Posting) []PostingSearchResponse {
+	responses := make([]PostingSearchResponse, len(postings))
 	for i, posting := range postings {
-		responses[i] = TitleSearchResponse{
+		responses[i] = PostingSearchResponse{
 			ID:            posting.ID,
 			Title:         posting.Title,
 			Url:           posting.URL.String(),

--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -52,7 +52,7 @@ func GetPostings(client *ent.Client) gin.HandlerFunc {
 
 		c.JSON(http.StatusOK, PostingSearchResponses{
 			Count:       totalCount,
-			Postings:    convertToTitleSearchResponse(postings),
+			Postings:    toPostingSearchResponses(postings),
 			HasNextPage: paging.HasNextPage(totalCount),
 		})
 	}
@@ -115,7 +115,7 @@ func getCompanyInfo(posting *ent.Posting) (string, string) {
 	return "Unknown", ""
 }
 
-func convertToTitleSearchResponse(postings []*ent.Posting) []PostingSearchResponse {
+func toPostingSearchResponses(postings []*ent.Posting) []PostingSearchResponse {
 	responses := make([]PostingSearchResponse, len(postings))
 
 	for _, posting := range postings {

--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -32,53 +32,60 @@ type PostingSearchResponses struct {
 	HasNextPage bool                    `json:"has_next_page"`
 }
 
-// ✅ GetPostings을 더 깔끔하게 정리
 func GetPostings(client *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		titleSearchParam := c.DefaultQuery("title", "")
 		tagsSearchParam := c.DefaultQuery("tags", "")
-
 		paging := common.GenerateTechPaging(c.Query("cursor"), c.Query("size"))
 
-		handlePostingsQuery(client, titleSearchParam, tagsSearchParam, paging, c)
+		postings, err := fetchPostings(client, titleSearchParam, tagsSearchParam, paging, c)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		totalCount, err := countPostings(client, titleSearchParam, tagsSearchParam, c)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, PostingSearchResponses{
+			Count:       totalCount,
+			Postings:    convertToTitleSearchResponse(postings),
+			HasNextPage: paging.HasNextPage(totalCount),
+		})
 	}
 }
 
-func handlePostingsQuery(client *ent.Client, title, tags string, paging common.TechbloghubPaging, c *gin.Context) {
-	searchParam := title
-	if searchParam == "" {
-		searchParam = tags
+func applySearchFilters(query *ent.PostingQuery, title, tags string) *ent.PostingQuery {
+	if title != "" {
+		query = query.Where(posting.TitleContainsFold(title))
+	}
+	// 태그 조회 케이스 -> postgresql ARRAY 검색 형식에 맞춰야함
+	// tags: [react,java]
+	// query : where tags @> ARRAY['react','java']
+	if tags != "" {
+		trimmed := strings.Trim(tags, "[]")
+		arr := strings.Split(trimmed, ",")
+		arrayQuery := "ARRAY" + fmt.Sprintf("['%s']", strings.Join(arr, ","))
+
+		query = query.Where(func(s *sql.Selector) {
+			s.Where(sql.ExprP(fmt.Sprintf("%s @> %s", s.C("tags"), arrayQuery)))
+		})
 	}
 
-	postings, err := fetchPostings(client, searchParam, paging, c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	totalCount, err := countPostings(client, searchParam, c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, PostingSearchResponses{
-		Count:       totalCount,
-		Postings:    convertToTitleSearchResponse(postings),
-		HasNextPage: paging.HasNextPage(totalCount),
-	})
+	return query
 }
 
-func fetchPostings(client *ent.Client, param string, paging common.TechbloghubPaging, c *gin.Context) ([]*ent.Posting, error) {
+func fetchPostings(client *ent.Client, title, tags string, paging common.TechbloghubPaging, c *gin.Context) ([]*ent.Posting, error) {
 	query := client.Posting.Query()
-
-	if param != "" {
-		query = applySearchFilter(query, param)
-	}
+	query = applySearchFilters(query, title, tags)
 
 	if paging.Cursor > common.CURSOR_DEFAULT {
 		query = query.Where(posting.IDLT(paging.Cursor))
 	}
+
 	return query.Where(posting.HasCompany()).
 		WithCompany(func(q *ent.CompanyQuery) {
 			q.Select(
@@ -87,38 +94,20 @@ func fetchPostings(client *ent.Client, param string, paging common.TechbloghubPa
 			)
 		}).
 		Order(
-			ent.Desc(posting.FieldID),
+			ent.Desc(posting.FieldPublishedAt),
 			ent.Desc(posting.FieldID),
 		).
 		Limit(paging.Size).
 		All(c.Request.Context())
 }
 
-func applySearchFilter(query *ent.PostingQuery, param string) *ent.PostingQuery {
-	// before: [react,java]
-	// after: ARRAY[react,java]
-	if strings.HasPrefix(param, "[") && strings.HasSuffix(param, "]") {
-		arrayQuery := "ARRAY" + param
-
-		query = query.Where(func(s *sql.Selector) {
-			s.Where(sql.ExprP(fmt.Sprintf("%s @> %s", s.C("tags"), arrayQuery)))
-		})
-		// 단일 제목으로 검색하는 케이스는 제목 검색
-	} else if param != "" {
-		query = query.Where(posting.TitleContainsFold(param))
-	}
-	return query
-}
-
-func countPostings(client *ent.Client, param string, c *gin.Context) (int, error) {
+func countPostings(client *ent.Client, title, tags string, c *gin.Context) (int, error) {
 	query := client.Posting.Query()
-	if param != "" {
-		query = applySearchFilter(query, param)
-	}
+	query = applySearchFilters(query, title, tags)
 	return query.Count(c)
 }
 
-// 대체 왜 못갖고오냐
+// 대체 왜 못갖고오냐!!!!
 func getCompanyInfo(posting *ent.Posting) (string, string) {
 	if posting.Edges.Company != nil {
 		return posting.Edges.Company.Name, posting.Edges.Company.LogoURL.String()
@@ -127,7 +116,7 @@ func getCompanyInfo(posting *ent.Posting) (string, string) {
 }
 
 func convertToTitleSearchResponse(postings []*ent.Posting) []PostingSearchResponse {
-	var responses []PostingSearchResponse
+	responses := make([]PostingSearchResponse, len(postings))
 
 	for _, posting := range postings {
 		companyName, logoURL := getCompanyInfo(posting)

--- a/internal/http/handler/postinghandler.go
+++ b/internal/http/handler/postinghandler.go
@@ -1,14 +1,15 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
-	"entgo.io/ent/dialect/sql/sqljson"
 	"github.com/gin-gonic/gin"
 	"github.com/techbloghub/server/ent"
+	"github.com/techbloghub/server/ent/company"
 	"github.com/techbloghub/server/ent/posting"
 	"github.com/techbloghub/server/internal/common"
 )
@@ -31,6 +32,7 @@ type PostingSearchResponses struct {
 	HasNextPage bool                    `json:"has_next_page"`
 }
 
+// ✅ GetPostings을 더 깔끔하게 정리
 func GetPostings(client *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		titleSearchParam := c.DefaultQuery("title", "")
@@ -38,108 +40,110 @@ func GetPostings(client *ent.Client) gin.HandlerFunc {
 
 		paging := common.GenerateTechPaging(c.Query("cursor"), c.Query("size"))
 
-		if titleSearchParam == "" && tagsSearchParam == "" {
-			posts, err := fetchPostings(client, "", paging, c)
-			totalCount, err := countTotalPostings(client, "", c)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-
-			c.JSON(http.StatusOK, PostingSearchResponses{
-				Count:       totalCount,
-				Postings:    convertToTitleSearchResponse(posts),
-				HasNextPage: paging.HasNextPage(totalCount),
-			})
-			return
-		}
-
-		if titleSearchParam != "" {
-			counts, err := countTotalPostings(client, titleSearchParam, c)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-			postings, err := fetchPostings(client, titleSearchParam, paging, c)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-
-			c.JSON(http.StatusOK, PostingSearchResponses{
-				Count:       counts,
-				Postings:    convertToTitleSearchResponse(postings),
-				HasNextPage: paging.HasNextPage(counts),
-			})
-		} else {
-			totalCount, err := countTotalPostings(client, tagsSearchParam, c)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-
-			postings, err := fetchPostings(client, tagsSearchParam, paging, c)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
-
-			c.JSON(http.StatusOK, PostingSearchResponses{
-				Count:       totalCount,
-				Postings:    convertToTitleSearchResponse(postings),
-				HasNextPage: paging.HasNextPage(totalCount),
-			})
-		}
+		handlePostingsQuery(client, titleSearchParam, tagsSearchParam, paging, c)
 	}
+}
+
+func handlePostingsQuery(client *ent.Client, title, tags string, paging common.TechbloghubPaging, c *gin.Context) {
+	searchParam := title
+	if searchParam == "" {
+		searchParam = tags
+	}
+
+	postings, err := fetchPostings(client, searchParam, paging, c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	totalCount, err := countPostings(client, searchParam, c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, PostingSearchResponses{
+		Count:       totalCount,
+		Postings:    convertToTitleSearchResponse(postings),
+		HasNextPage: paging.HasNextPage(totalCount),
+	})
 }
 
 func fetchPostings(client *ent.Client, param string, paging common.TechbloghubPaging, c *gin.Context) ([]*ent.Posting, error) {
-	query := client.Posting.Query().WithCompany()
-	if strings.Contains(param, ",") {
-		arr := strings.Split(param, ",")
+	query := client.Posting.Query()
+
+	if param != "" {
+		query = applySearchFilter(query, param)
+	}
+
+	if paging.Cursor > common.CURSOR_DEFAULT {
+		query = query.Where(posting.IDLT(paging.Cursor))
+	}
+	return query.Where(posting.HasCompany()).
+		WithCompany(func(q *ent.CompanyQuery) {
+			q.Select(
+				company.FieldLogoURL,
+				company.FieldName,
+			)
+		}).
+		Order(
+			ent.Desc(posting.FieldID),
+			ent.Desc(posting.FieldID),
+		).
+		Limit(paging.Size).
+		All(c.Request.Context())
+}
+
+func applySearchFilter(query *ent.PostingQuery, param string) *ent.PostingQuery {
+	// before: [react,java]
+	// after: ARRAY[react,java]
+	if strings.HasPrefix(param, "[") && strings.HasSuffix(param, "]") {
+		arrayQuery := "ARRAY" + param
+
 		query = query.Where(func(s *sql.Selector) {
-			s.Where(sqljson.ValueContains("tags", arr))
+			s.Where(sql.ExprP(fmt.Sprintf("%s @> %s", s.C("tags"), arrayQuery)))
 		})
+		// 단일 제목으로 검색하는 케이스는 제목 검색
 	} else if param != "" {
 		query = query.Where(posting.TitleContainsFold(param))
 	}
-	if paging.Cursor > 0 {
-		query = query.Where(posting.IDLT(paging.Cursor))
-	}
-
-	return query.Order(
-		ent.Desc(posting.FieldPublishedAt),
-		ent.Desc(posting.FieldID),
-	).Limit(paging.Size).All(c)
+	return query
 }
 
-func countTotalPostings(client *ent.Client, param string, c *gin.Context) (int, error) {
+func countPostings(client *ent.Client, param string, c *gin.Context) (int, error) {
 	query := client.Posting.Query()
 	if param != "" {
-		query = query.Where(posting.TitleContainsFold(param))
-	} else if strings.Contains(param, ",") {
-		arr := strings.Split(param, ",")
-		query = query.Where(func(s *sql.Selector) {
-			s.Where(sqljson.ValueContains("tags", arr))
-		})
+		query = applySearchFilter(query, param)
 	}
 	return query.Count(c)
 }
 
+// 대체 왜 못갖고오냐
+func getCompanyInfo(posting *ent.Posting) (string, string) {
+	if posting.Edges.Company != nil {
+		return posting.Edges.Company.Name, posting.Edges.Company.LogoURL.String()
+	}
+	return "Unknown", ""
+}
+
 func convertToTitleSearchResponse(postings []*ent.Posting) []PostingSearchResponse {
-	responses := make([]PostingSearchResponse, len(postings))
-	for i, posting := range postings {
-		responses[i] = PostingSearchResponse{
+	var responses []PostingSearchResponse
+
+	for _, posting := range postings {
+		companyName, logoURL := getCompanyInfo(posting)
+
+		responses = append(responses, PostingSearchResponse{
 			ID:            posting.ID,
 			Title:         posting.Title,
 			Url:           posting.URL.String(),
-			Company:       posting.Edges.Company.Name,
-			Logo:          posting.Edges.Company.LogoURL.String(),
+			Company:       companyName,
+			Logo:          logoURL,
 			Tags:          posting.Tags.ToStringSlice(),
 			CreateTime:    posting.CreateTime,
 			UpdateTime:    posting.UpdateTime,
 			PublishedTime: posting.PublishedAt,
-		}
+		})
 	}
+
 	return responses
 }


### PR DESCRIPTION
기존 포스트 조회 api 태그 검색 기능을 추가해뒀슴니당

자세한 명세는 **[요기](https://www.notion.so/iamjooon2/1aa3ffbfb3f980bdb961d0d920f47960?pvs=4)**

API 내려줄 때 Companay의 name, logo_url을 같이 내려주려고 했는데
entgo를 참 모르더라구요... 그래서 임시로 땜빵 메서드 만들어뒀슴니다